### PR TITLE
Environ list type

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"strings"
 
-	"gopkg.in/errgo.v1"
 	"github.com/juju/schema"
+	"gopkg.in/errgo.v1"
 )
 
 // What to do about reading content from paths?
@@ -123,8 +123,12 @@ const (
 	// Tint represents an integer type. Its canonical Go type is int.
 	Tint FieldType = "int"
 
-	// Tattrs represents an attribute map. Its canonical Go type is map[string]string.
+	// Tattrs represents an attribute map. Its canonical Go type is
+	// map[string]string.
 	Tattrs FieldType = "attrs"
+
+	// Tlist represents an list of strings. Its canonical Go type is []string
+	Tlist FieldType = "list"
 )
 
 var checkers = map[FieldType]schema.Checker{
@@ -132,6 +136,7 @@ var checkers = map[FieldType]schema.Checker{
 	Tbool:   schema.Bool(),
 	Tint:    schema.ForceInt(),
 	Tattrs:  attrsChecker{},
+	Tlist:   schema.List(schema.String()),
 }
 
 // Alternative possibilities to ValidationSchema to bear in mind for

--- a/fields_test.go
+++ b/fields_test.go
@@ -6,8 +6,8 @@ package environschema_test
 import (
 	"testing"
 
-	"github.com/juju/schema"
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/schema"
 
 	"gopkg.in/juju/environschema.v1"
 )
@@ -43,6 +43,9 @@ var validationSchemaTests = []struct {
 		"attrvalue": {
 			Type: environschema.Tattrs,
 		},
+		"listvalue": {
+			Type: environschema.Tlist,
+		},
 	},
 	tests: []valueTest{{
 		about: "all fields ok",
@@ -52,6 +55,7 @@ var validationSchemaTests = []struct {
 			"intvalue":              320.0,
 			"boolvalue":             true,
 			"attrvalue":             "a=b c=d",
+			"listvalue":             []interface{}{"a", "b", "c"},
 		},
 		expectVal: map[string]interface{}{
 			"stringvalue":           "hello",
@@ -59,6 +63,7 @@ var validationSchemaTests = []struct {
 			"mandatory-stringvalue": "goodbye",
 			"boolvalue":             true,
 			"attrvalue":             map[string]string{"a": "b", "c": "d"},
+			"listvalue":             []interface{}{"a", "b", "c"},
 		},
 	}, {
 		about: "non-mandatory fields missing",

--- a/sample.go
+++ b/sample.go
@@ -211,6 +211,8 @@ func sampleValue(t FieldType) interface{} {
 		return map[string]string{
 			"example": "value",
 		}
+	case Tlist:
+		return []string{"example"}
 	default:
 		panic(fmt.Errorf("unknown schema type %q", t))
 	}

--- a/sample_test.go
+++ b/sample_test.go
@@ -46,6 +46,10 @@ var sampleYAMLTests = []struct {
 			Type:        environschema.Tattrs,
 			Description: "attrs is an attribute list",
 		},
+		"list": {
+			Type:        environschema.Tlist,
+			Description: "list is a slice",
+		},
 	},
 	expect: `
 		|# attrs is an attribute list
@@ -66,6 +70,11 @@ var sampleYAMLTests = []struct {
 		|# foo is a string.
 		|#
 		|foo: foovalue
+		|
+		|# list is a slice
+		|#
+		|# list:
+		|#   - example
 	`,
 }, {
 	about: "when a value is not specified, it's commented out",
@@ -214,6 +223,9 @@ var sampleYAMLTests = []struct {
 		"attrsval": {
 			Type: environschema.Tattrs,
 		},
+		"listval": {
+			Type: environschema.Tlist,
+		},
 	},
 	expect: `
 		|# attrsval:
@@ -224,6 +236,9 @@ var sampleYAMLTests = []struct {
 		|# intval: 0
 		|
 		|# intval-with-example: 999
+		|
+		|# listval:
+		|#   - example
 	`,
 }, {
 	about: "secret values are marked as secret/immutable",


### PR DESCRIPTION
The environschema is an abstraction (unwanted/un-needed?) for creating
fields for a restricted set. With that in mind, we also need to start
exposing a list type so we gain a similar feature to controller
features.

The code is rather simple as we expose and existing type `schema.List`
and the tests just ensure it works as expected.